### PR TITLE
Create tag-only option

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,9 +23,10 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # maximum number of days since last release
           max-days: 7
+          # tag-only: true # create a tag instead of a release
 ```
 
 Note
 
-- This action works when the versioning scheme matches the pattern `^\d+\.\d+\.\d+$`.
+- This action works when the versioning scheme matches the pattern `^v?\d+\.\d+\.\d+$`.
 - A new release will only be created if there exists at least one prior release and there have been commits since the last release.

--- a/action.yml
+++ b/action.yml
@@ -11,6 +11,10 @@ inputs:
   max-days:
     required: true
     description: The maximum number of days since the last release
+  tag-only:
+    required: false
+    default: false
+    description: When true, create a tag instead of a release
 runs:
   using: "node16"
   main: "dist/index.js"


### PR DESCRIPTION
## Before this PR
autorelease always creates a release, does not allow for a `v` prefix on the version.

## After this PR
Add `tag-only` option to create tags. Optionally allow for `v` in the release name.


