### PR TITLE
Catch error instead of inspecting response status

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -98,7 +98,7 @@ export async function work(
   } else {
     core.info(`Creating a new tag ${newTag}`);
     try {
-      const result = await octokit.rest.git.createTag({
+      await octokit.rest.git.createTag({
         ...context.repo,
         tag: newTag,
         message: newTag,

--- a/src/main.ts
+++ b/src/main.ts
@@ -105,7 +105,7 @@ export async function work(
         type: "commit",
         object: latestCommit,
       });
-    } catch(error) {
+    } catch (error) {
       core.error("Failed to create tag:\n" + JSON.stringify(error));
     }
   }
@@ -123,7 +123,9 @@ async function run(): Promise<void> {
     if (error instanceof Error) {
       core.setFailed(error.message);
     } else {
-      core.setFailed("Encountered an unexpected error:\n" + JSON.stringify(error));
+      core.setFailed(
+        "Encountered an unexpected error:\n" + JSON.stringify(error),
+      );
     }
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -122,8 +122,9 @@ async function run(): Promise<void> {
   } catch (error) {
     if (error instanceof Error) {
       core.setFailed(error.message);
+    } else {
+      core.setFailed("Encountered an unexpected error:\n" + JSON.stringify(error));
     }
-    core.setFailed("Encountered an unexpected error:\n" + JSON.stringify(error));
   }
 }
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -97,15 +97,16 @@ export async function work(
     }
   } else {
     core.info(`Creating a new tag ${newTag}`);
-    const result = await octokit.rest.git.createTag({
-      ...context.repo,
-      tag: newTag,
-      message: newTag,
-      type: "commit",
-      object: latestCommit,
-    });
-    if (result.status != 201) {
-      core.error("Failed to create tag:\n" + JSON.stringify(result));
+    try {
+      const result = await octokit.rest.git.createTag({
+        ...context.repo,
+        tag: newTag,
+        message: newTag,
+        type: "commit",
+        object: latestCommit,
+      });
+    } catch(error) {
+      core.error("Failed to create tag:\n" + JSON.stringify(error));
     }
   }
 }
@@ -122,6 +123,7 @@ async function run(): Promise<void> {
     if (error instanceof Error) {
       core.setFailed(error.message);
     }
+    core.setFailed("Encountered an unexpected error:\n" + JSON.stringify(error));
   }
 }
 


### PR DESCRIPTION
## Before this PR
We're still unable to trap createTag errors it seems.

## After this PR
Expand try/catch handling.


