### PR TITLE
Upgrade to node24 runtime and publish as v3

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,4 +40,4 @@ jobs:
           COMMIT_EMAIL: "melliotbot[bot]@users.noreply.github.com"
           MESSAGE: "Release of changes in ${{ github.sha }}"
           BRANCH: release
-          TAG: v2
+          TAG: v3

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: autorelease
-        uses: markelliot/autorelease@v2
+        uses: markelliot/autorelease@v3
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           # maximum number of days since last release

--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ inputs:
     default: false
     description: When true, create a tag instead of a release
 runs:
-  using: "node20"
+  using: "node24"
   main: "dist/index.js"


### PR DESCRIPTION
## What

Upgrades the action to the **node24** runtime and bumps the published major version to **v3**.

## Changes

- **`action.yml`** — `runs.using` changed from `node20` → `node24`. This is the runtime GitHub Actions launches `dist/index.js` under when a consumer invokes the action.
- **`.github/workflows/release.yml`** — release `TAG` bumped from `v2` → `v3`, so the next push to `develop` publishes the moving major tag as `v3`.
- **`README.md`** — usage example updated to `markelliot/autorelease@v3`.

## Why a new major

The runtime change affects consumers: a self-hosted runner older than ~mid-2025 (runner < v2.327.0) won't recognize `node24` and would fail. Cutting v3 keeps existing `@v2` consumers on the node20 build and lets them opt into node24 on their own schedule.

## Notes

- CI and release already run on Node 24 (`setup-node@v6`, `node-version: "24"`), so `dist/` is already built under Node 24 — this only aligns the consumer runtime.
- On merge to `develop`, the Release workflow rebuilds `dist/`, pushes to the `release` branch, and force-tags `v3`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)