### PR TITLE
Add patch option to increment patch instead of minor

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ jobs:
           # maximum number of days since last release
           max-days: 7
           # tag-only: true # create a tag instead of a release
+          # patch: true # increment the patch number instead of the minor number
 ```
 
 Note

--- a/action.yml
+++ b/action.yml
@@ -15,6 +15,10 @@ inputs:
     required: false
     default: false
     description: When true, create a tag instead of a release
+  patch:
+    required: false
+    default: false
+    description: When true, increment the patch number instead of the minor number
 runs:
   using: "node24"
   main: "dist/index.js"

--- a/src/main.ts
+++ b/src/main.ts
@@ -12,6 +12,7 @@ export async function work(
   octokit: InstanceType<typeof GitHub>,
   maxDays: number,
   tagOnly: boolean,
+  patch: boolean,
   dryRun: boolean,
 ) {
   const context = github.context;
@@ -79,7 +80,9 @@ export async function work(
     return;
   }
 
-  const newTag = `${releaseComponents[1]}${releaseComponents[2]}.${parseInt(releaseComponents[3]) + 1}.0`;
+  const newTag = patch
+    ? `${releaseComponents[1]}${releaseComponents[2]}.${releaseComponents[3]}.${parseInt(releaseComponents[4]) + 1}`
+    : `${releaseComponents[1]}${releaseComponents[2]}.${parseInt(releaseComponents[3]) + 1}.0`;
   if (dryRun) {
     core.info("Running in dryRun mode, skipping release creation.");
     return;
@@ -122,8 +125,9 @@ async function run(): Promise<void> {
     const authToken = core.getInput("github-token");
     const maxDays = parseInt(core.getInput("max-days"));
     const tagOnly = core.getInput("tag-only") === "true";
+    const patch = core.getInput("patch") === "true";
     const octokit = github.getOctokit(authToken);
-    work(octokit, maxDays, tagOnly, false);
+    work(octokit, maxDays, tagOnly, patch, false);
   } catch (error) {
     if (error instanceof Error) {
       core.setFailed(error.message);


### PR DESCRIPTION
## Summary
Adds an optional `patch` input to the action. When `true`, the new version increments the patch number (`<major>.<minor>.<patch+1>`) instead of the default minor bump (`<major>.<minor+1>.0`).

## Changes
- `action.yml` — new optional `patch` input (default `false`)
- `src/main.ts` — `work()` accepts a `patch` flag and computes the new tag accordingly; `run()` reads the `patch` input
- `README.md` — documents the new input

## Notes
`dist/` is gitignored and built during release, so it isn't part of this diff. `yarn package` (lint + tsc + ncc) ran clean against the source change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)